### PR TITLE
Removed hard coded cluster domain suffix

### DIFF
--- a/charts/maas/templates/bin/_export-api-key.sh.tpl
+++ b/charts/maas/templates/bin/_export-api-key.sh.tpl
@@ -23,7 +23,7 @@ function clear_secret {
         --header='Content-Type: application/json' \
         --header="Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
         --method=DELETE \
-        https://kubernetes.default.svc.cluster.local/api/v1/namespaces/${SECRET_NAMESPACE}/secrets/${SECRET_NAME}
+        https://kubernetes/api/v1/namespaces/${SECRET_NAMESPACE}/secrets/${SECRET_NAME}
 }
 
 function post_secret {
@@ -34,7 +34,7 @@ function post_secret {
         --header="Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
         --method=POST \
         --body-file=/tmp/secret.json \
-        https://kubernetes.default.svc.cluster.local/api/v1/namespaces/${SECRET_NAMESPACE}/secrets \
+        https://kubernetes/api/v1/namespaces/${SECRET_NAMESPACE}/secrets \
         2>&1
 }
 


### PR DESCRIPTION
I think it would be better to use just a service name when calling `kubernetes` service instead of hard coding fqdn. That's because pod's resolver will automatically try search domains and eventually get valid response.

When cluster domain suffix is hard coded as `kubernetes.default.svc.cluster.local` then secret creation will fail with the following error.

```
+ echo 'Secret creation failed'
+ echo --2019-08-26 14:46:24-- https://kubernetes.default.svc.cluster.local/api/v1/namespaces/default/secrets Resolving kubernetes.default.svc.cluster.local '(kubernetes.default.svc.cluster.local)...' failed: Temporary failure in name resolution. wget: unable to resolve host address ''\''kubernetes.default.svc.cluster.local'\'''
Secret creation failed
--2019-08-26 14:46:24-- https://kubernetes.default.svc.cluster.local/api/v1/namespaces/default/secrets Resolving kubernetes.default.svc.cluster.local (kubernetes.default.svc.cluster.local)... failed: Temporary failure in name resolution. wget: unable to resolve host address 'kubernetes.default.svc.cluster.local'
+ sleep 15
```

This issue will not happen when service name is used without suffix.

```
> k exec -ti busybox -- nslookup kubernetes
Server:    169.254.25.10
Address 1: 169.254.25.10

Name:      kubernetes
Address 1: 10.3.0.1 kubernetes.default.svc.k8s-cluster.local
```